### PR TITLE
Add click-triggered flip animation and embed images

### DIFF
--- a/flipTiles.pro
+++ b/flipTiles.pro
@@ -6,7 +6,7 @@ SOURCES += main.cpp \
 HEADERS += mainwindow.h \
     tileitem.h
 
-# No resources
+RESOURCES += resources.qrc
 
 TEMPLATE = app
 TARGET = flipTiles

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1,17 +1,19 @@
 #include "mainwindow.h"
 #include <QGraphicsPixmapItem>
 #include <QDir>
+#include <QEvent>
 
 MainWindow::MainWindow(QWidget *parent)
-    : QMainWindow(parent), view(new QGraphicsView(this)), scene(new QGraphicsScene(this)), rows(4), cols(4)
+    : QMainWindow(parent), view(new QGraphicsView(this)), scene(new QGraphicsScene(this)), rows(4), cols(4), animationStarted(false)
 {
     setFixedSize(800, 600);
     view->setFixedSize(800, 600);
     setCentralWidget(view);
     view->setScene(scene);
+    view->installEventFilter(this);
 
-    QPixmap img1("image1.jpg");
-    QPixmap img2("image2.jpg");
+    QPixmap img1(":/image1.jpg");
+    QPixmap img2(":/image2.jpg");
 
     if (img1.isNull() || img2.isNull()) {
         // If images failed to load, just fill with gray
@@ -39,8 +41,6 @@ MainWindow::MainWindow(QWidget *parent)
     }
 
     scene->setSceneRect(0, 0, img1.width(), img1.height());
-
-    startAnimation();
 }
 
 void MainWindow::startAnimation()
@@ -54,6 +54,18 @@ void MainWindow::startAnimation()
             delay += 100; // wave effect
         }
     }
+}
+
+bool MainWindow::eventFilter(QObject *obj, QEvent *event)
+{
+    if (obj == view && event->type() == QEvent::MouseButtonPress) {
+        if (!animationStarted) {
+            animationStarted = true;
+            startAnimation();
+        }
+        return true; // consume
+    }
+    return QMainWindow::eventFilter(obj, event);
 }
 
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -6,6 +6,7 @@
 #include <QGraphicsScene>
 #include <QTimer>
 #include "tileitem.h"
+#include <QEvent>
 
 class MainWindow : public QMainWindow
 {
@@ -20,6 +21,10 @@ private:
     QVector<TileItem*> tiles;
     int rows;
     int cols;
+    bool animationStarted;
+
+protected:
+    bool eventFilter(QObject *obj, QEvent *event) override;
 };
 
 #endif // MAINWINDOW_H

--- a/resources.qrc
+++ b/resources.qrc
@@ -1,0 +1,6 @@
+<RCC>
+    <qresource prefix="/">
+        <file>image1.jpg</file>
+        <file>image2.jpg</file>
+    </qresource>
+</RCC>


### PR DESCRIPTION
## Summary
- trigger the wave flip animation on the first mouse click
- embed image assets using a Qt resource file
- update `flipTiles.pro` to include the new resources

## Testing
- `qmake flipTiles.pro -o Makefile && make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6877529557f08333b542e41ce43a362a