### PR TITLE
Enable cyclical flipboard animation

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -4,7 +4,7 @@
 #include <QEvent>
 
 MainWindow::MainWindow(QWidget *parent)
-    : QMainWindow(parent), view(new QGraphicsView(this)), scene(new QGraphicsScene(this)), rows(4), cols(4), animationStarted(false)
+    : QMainWindow(parent), view(new QGraphicsView(this)), scene(new QGraphicsScene(this)), rows(8), cols(8)
 {
     setFixedSize(800, 600);
     view->setFixedSize(800, 600);
@@ -59,10 +59,7 @@ void MainWindow::startAnimation()
 bool MainWindow::eventFilter(QObject *obj, QEvent *event)
 {
     if (obj == view && event->type() == QEvent::MouseButtonPress) {
-        if (!animationStarted) {
-            animationStarted = true;
-            startAnimation();
-        }
+        startAnimation();
         return true; // consume
     }
     return QMainWindow::eventFilter(obj, event);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -21,7 +21,6 @@ private:
     QVector<TileItem*> tiles;
     int rows;
     int cols;
-    bool animationStarted;
 
 protected:
     bool eventFilter(QObject *obj, QEvent *event) override;

--- a/tileitem.cpp
+++ b/tileitem.cpp
@@ -1,41 +1,54 @@
 #include "tileitem.h"
 
 TileItem::TileItem(const QPixmap &front, const QPixmap &back, QGraphicsItem *parent)
-    : QGraphicsPixmapItem(parent), m_front(front), m_back(back), m_scaleX(1.0)
+    : QGraphicsPixmapItem(parent), m_front(front), m_back(back), m_frontSide(true)
 {
     setPixmap(m_front);
-    setTransformOriginPoint(boundingRect().width()/2, boundingRect().height()/2);
+    setTransformOriginPoint(boundingRect().width() / 2.0, boundingRect().height() / 2.0);
+
+    m_rotation = new QGraphicsRotation(this);
+    m_rotation->setAxis(Qt::XAxis);
+    m_rotation->setAngle(0);
+    QList<QGraphicsTransform*> transforms;
+    transforms << m_rotation;
+    setTransformations(transforms);
 
     group = new QSequentialAnimationGroup(this);
-    QPropertyAnimation *first = new QPropertyAnimation(this, "scaleX");
-    first->setDuration(300);
-    first->setStartValue(1.0);
-    first->setEndValue(0.0);
-    QPropertyAnimation *second = new QPropertyAnimation(this, "scaleX");
-    second->setDuration(300);
-    second->setStartValue(0.0);
-    second->setEndValue(1.0);
-
-    connect(first, &QAbstractAnimation::finished, [this]() {
-        setPixmap(m_back);
-    });
-
-    group->addAnimation(first);
-    group->addAnimation(second);
-}
-
-void TileItem::setScaleX(qreal s)
-{
-    m_scaleX = s;
-    QTransform t;
-    t.scale(s, 1.0);
-    setTransform(t);
 }
 
 void TileItem::startFlip()
 {
     if (group->state() == QAbstractAnimation::Running)
         return;
+
+    group->clear();
+
+    int startAngle = m_frontSide ? 0 : 180;
+    int midAngle = startAngle + 90;
+    int endAngle = startAngle + 180;
+
+    QPropertyAnimation *first = new QPropertyAnimation(m_rotation, "angle", group);
+    first->setDuration(300);
+    first->setStartValue(startAngle);
+    first->setEndValue(midAngle);
+
+    connect(first, &QAbstractAnimation::finished, [this]() {
+        m_frontSide = !m_frontSide;
+        setPixmap(m_frontSide ? m_front : m_back);
+    });
+
+    QPropertyAnimation *second = new QPropertyAnimation(m_rotation, "angle", group);
+    second->setDuration(300);
+    second->setStartValue(midAngle);
+    second->setEndValue(endAngle);
+
+    connect(group, &QSequentialAnimationGroup::finished, [this, endAngle]() {
+        m_rotation->setAngle(endAngle % 360);
+    });
+
+    group->addAnimation(first);
+    group->addAnimation(second);
+
     group->start();
 }
 

--- a/tileitem.h
+++ b/tileitem.h
@@ -4,23 +4,21 @@
 #include <QGraphicsPixmapItem>
 #include <QSequentialAnimationGroup>
 #include <QPropertyAnimation>
+#include <QGraphicsRotation>
 
 class TileItem : public QObject, public QGraphicsPixmapItem
 {
     Q_OBJECT
-    Q_PROPERTY(qreal scaleX READ scaleX WRITE setScaleX)
 public:
     TileItem(const QPixmap &front, const QPixmap &back, QGraphicsItem *parent = nullptr);
-
-    qreal scaleX() const { return m_scaleX; }
-    void setScaleX(qreal s);
 
     void startFlip();
 
 private:
     QPixmap m_front;
     QPixmap m_back;
-    qreal m_scaleX;
+    bool m_frontSide;
+    QGraphicsRotation *m_rotation;
     QSequentialAnimationGroup *group;
 };
 


### PR DESCRIPTION
## Summary
- update `TileItem` to use `QGraphicsRotation` and toggle images every click
- shrink the tiles by switching to an 8×8 grid
- trigger board flip on every mouse click

## Testing
- `qmake flipTiles.pro && make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_687754621dd083338a0bfda3e857f1a3