### PR TITLE
Update tile flip animation

### DIFF
--- a/tileitem.h
+++ b/tileitem.h
@@ -5,6 +5,7 @@
 #include <QSequentialAnimationGroup>
 #include <QPropertyAnimation>
 #include <QGraphicsRotation>
+#include <QParallelAnimationGroup>
 
 class TileItem : public QObject, public QGraphicsPixmapItem
 {


### PR DESCRIPTION
## Summary
- pivot tile rotation at top edge
- animate like tearing a calendar page
- reset angle after flip

## Testing
- `qmake`
- `make -j2`
- `QT_QPA_PLATFORM=offscreen ./flipTiles` *(fails: QStandardPaths warning)*

------
https://chatgpt.com/codex/tasks/task_e_6877594a08c08333879d185b4b6c5961