### PR TITLE
Modify tile animation: drop and wobble cascade

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -31,10 +31,10 @@ MainWindow::MainWindow(QWidget *parent)
     for (int r = 0; r < rows; ++r) {
         for (int c = 0; c < cols; ++c) {
             QPixmap front = frontImage.copy(c * tileW, r * tileH, tileW, tileH);
-            QPixmap back = backImage.copy(c * tileW, r * tileH, tileW, tileH);
 
-            TileItem *tile = new TileItem(front, back);
+            TileItem *tile = new TileItem(front);
             tile->setPos(c * tileW, r * tileH);
+            tile->setBaseY(tile->y());
             scene->addItem(tile);
             tiles.append(tile);
             connect(tile, &TileItem::flipFinished, this, &MainWindow::onTileFinished);
@@ -49,13 +49,12 @@ void MainWindow::startAnimation()
 {
     finishedCount = 0;
     scene->setBackgroundBrush(QBrush(showingFront ? frontImage : backImage));
-    int delay = 0;
     int idx = 0;
     for (int r = 0; r < rows; ++r) {
         for (int c = 0; c < cols; ++c) {
             TileItem *tile = tiles.at(idx++);
-            QTimer::singleShot(delay, tile, [tile]() { tile->startFlip(); });
-            delay += 100; // wave effect
+            int delay = (r + c) * 100; // cascade from corner
+            QTimer::singleShot(delay, tile, [tile]() { tile->startAnimation(); });
         }
     }
 }

--- a/tileitem.cpp
+++ b/tileitem.cpp
@@ -1,14 +1,13 @@
 #include "tileitem.h"
-#include <QParallelAnimationGroup>
 
-TileItem::TileItem(const QPixmap &front, const QPixmap &back, QGraphicsItem *parent)
-    : QGraphicsPixmapItem(parent), m_front(front), m_back(back), m_frontSide(true)
+TileItem::TileItem(const QPixmap &pixmap, QGraphicsItem *parent)
+    : QGraphicsPixmapItem(parent), m_pixmap(pixmap)
 {
-    setPixmap(m_front);
-    setTransformOriginPoint(boundingRect().width() / 2.0, 0);
+    setPixmap(m_pixmap);
+    setTransformOriginPoint(boundingRect().width() / 2.0, boundingRect().height());
 
     m_rotation = new QGraphicsRotation(this);
-    m_rotation->setAxis(Qt::XAxis);
+    m_rotation->setAxis(Qt::ZAxis);
     m_rotation->setAngle(0);
     QList<QGraphicsTransform*> transforms;
     transforms << m_rotation;
@@ -19,48 +18,51 @@ TileItem::TileItem(const QPixmap &front, const QPixmap &back, QGraphicsItem *par
             this, &TileItem::onGroupFinished);
 }
 
-void TileItem::startFlip()
+void TileItem::setBaseY(qreal y)
+{
+    m_baseY = y;
+    setY(y);
+}
+
+void TileItem::startAnimation()
 {
     if (group->state() == QAbstractAnimation::Running)
         return;
 
     group->clear();
 
-    int startAngle = 0;
-    int midAngle = 90;
-    int endAngle = 180;
+    const qreal startY = m_baseY - boundingRect().height();
+    const qreal endY = m_baseY;
+    setY(startY);
 
-    QSequentialAnimationGroup *rotGroup = new QSequentialAnimationGroup(group);
-
-    QPropertyAnimation *first = new QPropertyAnimation(m_rotation, "angle");
-    first->setDuration(300);
-    first->setStartValue(startAngle);
-    first->setEndValue(midAngle);
-
-    connect(first, &QAbstractAnimation::finished, [this]() {
-        m_frontSide = !m_frontSide;
-        setPixmap(m_frontSide ? m_front : m_back);
-    });
-
-    QPropertyAnimation *second = new QPropertyAnimation(m_rotation, "angle");
-    second->setDuration(300);
-    second->setStartValue(midAngle);
-    second->setEndValue(endAngle);
-
-    rotGroup->addAnimation(first);
-    rotGroup->addAnimation(second);
-
-    const qreal dy = boundingRect().height() * 0.2;
     QPropertyAnimation *move = new QPropertyAnimation(this, "y");
     move->setDuration(600);
-    move->setStartValue(y());
-    move->setEndValue(y() + dy);
+    move->setStartValue(startY);
+    move->setEndValue(endY);
 
-    QParallelAnimationGroup *flipGroup = new QParallelAnimationGroup(group);
-    flipGroup->addAnimation(rotGroup);
-    flipGroup->addAnimation(move);
+    QSequentialAnimationGroup *wobble = new QSequentialAnimationGroup(group);
 
-    group->addAnimation(flipGroup);
+    QPropertyAnimation *rot1 = new QPropertyAnimation(m_rotation, "angle");
+    rot1->setDuration(100);
+    rot1->setStartValue(0);
+    rot1->setEndValue(-10);
+
+    QPropertyAnimation *rot2 = new QPropertyAnimation(m_rotation, "angle");
+    rot2->setDuration(100);
+    rot2->setStartValue(-10);
+    rot2->setEndValue(10);
+
+    QPropertyAnimation *rot3 = new QPropertyAnimation(m_rotation, "angle");
+    rot3->setDuration(100);
+    rot3->setStartValue(10);
+    rot3->setEndValue(0);
+
+    wobble->addAnimation(rot1);
+    wobble->addAnimation(rot2);
+    wobble->addAnimation(rot3);
+
+    group->addAnimation(move);
+    group->addAnimation(wobble);
 
     group->start();
 }
@@ -68,7 +70,7 @@ void TileItem::startFlip()
 void TileItem::onGroupFinished()
 {
     m_rotation->setAngle(0);
-    setY(y() - boundingRect().height() * 0.2);
+    setY(m_baseY);
     emit flipFinished();
 }
 

--- a/tileitem.h
+++ b/tileitem.h
@@ -11,9 +11,10 @@ class TileItem : public QObject, public QGraphicsPixmapItem
 {
     Q_OBJECT
 public:
-    TileItem(const QPixmap &front, const QPixmap &back, QGraphicsItem *parent = nullptr);
+    explicit TileItem(const QPixmap &pixmap, QGraphicsItem *parent = nullptr);
 
-    void startFlip();
+    void setBaseY(qreal y);
+    void startAnimation();
 
 signals:
     void flipFinished();
@@ -22,11 +23,10 @@ private slots:
     void onGroupFinished();
 
 private:
-    QPixmap m_front;
-    QPixmap m_back;
-    bool m_frontSide;
+    QPixmap m_pixmap;
     QGraphicsRotation *m_rotation;
     QSequentialAnimationGroup *group;
+    qreal m_baseY {0};
 };
 
 #endif // TILEITEM_H


### PR DESCRIPTION
## Summary
- animate tiles with a downward drop followed by a wobble
- remove back images so each tile has one side
- trigger animations in a corner-to-corner cascade

## Testing
- `qmake && make -j4`
- `./flipTiles` *(fails: could not connect to display)*

------
https://chatgpt.com/codex/tasks/task_e_68775c4be2908333847f21ea0a8c89cf