### PR TITLE
Add calendar-style flip animation

### DIFF
--- a/tileitem.cpp
+++ b/tileitem.cpp
@@ -1,13 +1,16 @@
 #include "tileitem.h"
+#include <QEasingCurve>
 
 TileItem::TileItem(const QPixmap &pixmap, QGraphicsItem *parent)
     : QGraphicsPixmapItem(parent), m_pixmap(pixmap)
 {
     setPixmap(m_pixmap);
-    setTransformOriginPoint(boundingRect().width() / 2.0, boundingRect().height());
+    // Anchor transformations at the top edge so the tile flips like a page
+    setTransformOriginPoint(boundingRect().width() / 2.0, 0);
 
     m_rotation = new QGraphicsRotation(this);
-    m_rotation->setAxis(Qt::ZAxis);
+    // Rotate around the X axis to mimic a calendar page
+    m_rotation->setAxis(Qt::XAxis);
     m_rotation->setAngle(0);
     QList<QGraphicsTransform*> transforms;
     transforms << m_rotation;
@@ -31,38 +34,29 @@ void TileItem::startAnimation()
 
     group->clear();
 
-    const qreal startY = m_baseY - boundingRect().height();
-    const qreal endY = m_baseY;
+    const qreal startY = m_baseY;
+    const qreal endY = m_baseY + boundingRect().height();
     setY(startY);
+    m_rotation->setAngle(0);
+
+    QParallelAnimationGroup *flip = new QParallelAnimationGroup(group);
 
     QPropertyAnimation *move = new QPropertyAnimation(this, "y");
     move->setDuration(600);
     move->setStartValue(startY);
     move->setEndValue(endY);
+    move->setEasingCurve(QEasingCurve::InQuad);
 
-    QSequentialAnimationGroup *wobble = new QSequentialAnimationGroup(group);
+    QPropertyAnimation *rot = new QPropertyAnimation(m_rotation, "angle");
+    rot->setDuration(600);
+    rot->setStartValue(0);
+    rot->setEndValue(90);
+    rot->setEasingCurve(QEasingCurve::InQuad);
 
-    QPropertyAnimation *rot1 = new QPropertyAnimation(m_rotation, "angle");
-    rot1->setDuration(100);
-    rot1->setStartValue(0);
-    rot1->setEndValue(-10);
+    flip->addAnimation(move);
+    flip->addAnimation(rot);
 
-    QPropertyAnimation *rot2 = new QPropertyAnimation(m_rotation, "angle");
-    rot2->setDuration(100);
-    rot2->setStartValue(-10);
-    rot2->setEndValue(10);
-
-    QPropertyAnimation *rot3 = new QPropertyAnimation(m_rotation, "angle");
-    rot3->setDuration(100);
-    rot3->setStartValue(10);
-    rot3->setEndValue(0);
-
-    wobble->addAnimation(rot1);
-    wobble->addAnimation(rot2);
-    wobble->addAnimation(rot3);
-
-    group->addAnimation(move);
-    group->addAnimation(wobble);
+    group->addAnimation(flip);
 
     group->start();
 }


### PR DESCRIPTION
## Summary
- change animation pivot to top edge of tile
- rotate tiles on the X axis and slide them down to mimic a calendar page flip
- use a parallel animation for rotation and movement

## Testing
- `qmake`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68775e5438cc8333b0dd034b550c1104