### PR TITLE
Fix image switching in tile flip animation

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -48,7 +48,7 @@ MainWindow::MainWindow(QWidget *parent)
 void MainWindow::startAnimation()
 {
     finishedCount = 0;
-    scene->setBackgroundBrush(QBrush(showingFront ? frontImage : backImage));
+    scene->setBackgroundBrush(QBrush(showingFront ? backImage : frontImage));
     int idx = 0;
     for (int r = 0; r < rows; ++r) {
         for (int c = 0; c < cols; ++c) {
@@ -73,6 +73,16 @@ void MainWindow::onTileFinished()
     ++finishedCount;
     if (finishedCount == tiles.size()) {
         showingFront = !showingFront;
+        QPixmap &img = showingFront ? frontImage : backImage;
+        int tileW = img.width() / cols;
+        int tileH = img.height() / rows;
+        int idx = 0;
+        for (int r = 0; r < rows; ++r) {
+            for (int c = 0; c < cols; ++c) {
+                QPixmap piece = img.copy(c * tileW, r * tileH, tileW, tileH);
+                tiles.at(idx++)->updatePixmap(piece);
+            }
+        }
         updateBackground();
     }
 }

--- a/tileitem.cpp
+++ b/tileitem.cpp
@@ -42,13 +42,13 @@ void TileItem::startAnimation()
     QParallelAnimationGroup *flip = new QParallelAnimationGroup(group);
 
     QPropertyAnimation *move = new QPropertyAnimation(this, "y");
-    move->setDuration(600);
+    move->setDuration(1200);
     move->setStartValue(startY);
     move->setEndValue(endY);
     move->setEasingCurve(QEasingCurve::InQuad);
 
     QPropertyAnimation *rot = new QPropertyAnimation(m_rotation, "angle");
-    rot->setDuration(600);
+    rot->setDuration(1200);
     rot->setStartValue(0);
     rot->setEndValue(90);
     rot->setEasingCurve(QEasingCurve::InQuad);
@@ -66,6 +66,12 @@ void TileItem::onGroupFinished()
     m_rotation->setAngle(0);
     setY(m_baseY);
     emit flipFinished();
+}
+
+void TileItem::updatePixmap(const QPixmap &pixmap)
+{
+    m_pixmap = pixmap;
+    setPixmap(m_pixmap);
 }
 
 

--- a/tileitem.h
+++ b/tileitem.h
@@ -15,6 +15,7 @@ public:
 
     void setBaseY(qreal y);
     void startAnimation();
+    void updatePixmap(const QPixmap &pixmap);
 
 signals:
     void flipFinished();


### PR DESCRIPTION
## Summary
- slow down tile animations for clearer flipping
- reveal the next image correctly during transitions
- update tile pixmaps after each flip

## Testing
- `qmake flipTiles.pro -o Makefile`
- `make -j$(nproc)`
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_68775fcecbd08333844dbb8c24688726